### PR TITLE
Add cluster_info Webmachine resource, disabled by default.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 *.log
 *.script
 .eunit/
+deps 
 erl_crash.dump

--- a/README.md
+++ b/README.md
@@ -94,6 +94,38 @@ generate a report will throw undefined function exceptions.  As noted
 at the top of this section, the `riak_err` application must be
 compiled and packaged together with the `cluster_info` application.
 
+Requesting dumps over HTTP
+--------------------------
+
+`cluster_info` includes a Webmachine resource that allows you to fetch
+dumps over HTTP, which could be useful as part of an automated
+monitoring system. The resource is disabled by default, but can be
+enabled by setting the `cluster_info` environment variable
+`web_enabled` to `true`. That will cause the resource to be added to
+the Webmachine routes at the default URI of "/cluster_info". The path
+to the resource can also be configured via the `web_path` variable,
+which should be a valid Webmachine path specification. Finally, the
+resource makes use of the local filesystem for storing `cluster_info`
+dumps while they are being generated. The path it uses defaults to the
+operating system's temporary directory but can be configured via the
+`temp_dir` variable.
+
+Configuration example:
+
+    {cluster_info, [{web_enabled, true},
+                    {web_path, ["ci"]},
+                    {temp_dir, "/tmp/ci/dumps"}]}.
+
+By default, the resource performs only a local `cluster_info` dump,
+but can also dump all connected nodes or specific nodes using the
+`node` query parameter. The following request will dump all nodes:
+
+    GET /cluster_info?node=all
+
+The request below will dump nodes `ci@a` and `ci@b`:
+
+    GET /cluster_info?node=ci@a&node=ci@b
+
 Licensing
 ---------
 

--- a/rebar.config
+++ b/rebar.config
@@ -5,5 +5,5 @@
             , {i, "./priv/"}
             , debug_info
            ]}.
-
+{deps, [{webmachine, "1.8.*", {git, "git://github.com/basho/webmachine.git", {branch, "master"}}}]}.
 {require_otp_vsn, "R13B04|R14"}.

--- a/src/cluster_info.app.src
+++ b/src/cluster_info.app.src
@@ -26,8 +26,6 @@
   {registered, []},
   {applications, [kernel, stdlib, sasl]},
   {mod, {cluster_info, []}},
-  {modules, [cluster_info
-            , cluster_info_ex
-            ]}
+  {env, [{web_enabled, false}]}
  ]
 }.

--- a/src/cluster_info.erl
+++ b/src/cluster_info.erl
@@ -71,6 +71,16 @@ start(_Type, _StartArgs) ->
         _ ->
             ok
     end,
+    case application:get_env(?MODULE, web_enabled) of
+        true ->
+            application:start(webmachine),
+            Route = case application:get_env(?MODULE, web_path) of
+                        undefined -> ["cluster_info"];
+                        Path -> Path
+                    end,
+            webmachine_router:add_route({Route, cluster_info_wm, []});
+        _ -> ok
+    end,
     {ok, spawn(fun() -> receive pro_forma -> ok end end)}.
 
 %% Lesser-used callbacks....

--- a/src/cluster_info_wm.erl
+++ b/src/cluster_info_wm.erl
@@ -1,0 +1,66 @@
+-module(cluster_info_wm).
+
+-export([init/1,
+         malformed_request/2,
+         content_types_provided/2,
+         %% encodings_provided/2,
+         to_text/2]).
+
+-include_lib("webmachine/include/webmachine.hrl").
+
+-define(CHUNK_SIZE, 32768).
+
+-record(state, {temp :: string(),
+                nodes=[] :: list(string()) | atom}).
+
+init([]) ->
+    Temp = case application:get_env(cluster_info, temp_dir) of
+               undefined ->
+                   os:getenv("TMPDIR");
+               {ok, Dir} -> Dir
+           end,
+    {ok, #state{temp = Temp}}.
+
+malformed_request(RD, State) ->
+    KnownNodes = [ atom_to_list(N) || N <- [node()|nodes()] ],
+    {RequestedNodes, RD1} = case proplists:get_all_values("node", wrq:req_qs(RD)) of
+                                [] ->
+                                    {local, RD};
+                                ["all"] ->
+                                    {all, RD};
+                                List ->
+                                    {Known, Unknown} = lists:partition(fun(N) -> lists:member(N, KnownNodes) end, List),
+                                    case length(Unknown) of
+                                        0 -> {[ list_to_existing_atom(Node) || Node <- Known], RD};
+                                        _ ->
+                                            {false, wrq:set_resp_header("Content-Type", "text/plain", wrq:set_resp_body(io_lib:format("Unknown nodes: ~p~n", [Unknown]), RD))}
+                                    end
+                            end,
+    {RequestedNodes =:= false, RD1, State#state{nodes=RequestedNodes}}.
+
+
+content_types_provided(RD, State) ->
+    {[{"text/plain", to_text}], RD, State}.
+
+to_text(RD, State=#state{temp = Temp, nodes=Nodes}) ->
+    Filename = filename:join([Temp, integer_to_list(erlang:phash2([RD, self()]))]),
+    dump(Nodes, Filename),
+    {ok, Handle} = file:open(Filename, [read, read_ahead, binary]),
+    {{stream, stream_file(Handle, Filename)}, RD, State}.
+
+stream_file(Handle, File) ->
+    case file:read(Handle, ?CHUNK_SIZE) of
+        eof ->
+            file:close(Handle),
+            file:delete(File),
+            {<<>>, done};
+        {ok, Data} ->
+            {Data, fun() -> stream_file(Handle, File) end}
+    end.
+
+dump(local, Filename) ->
+    cluster_info:dump_local_node(Filename);
+dump(all, Filename) ->
+    cluster_info:dump_all_connected(Filename);
+dump(Nodes, Filename) ->
+    cluster_info:dump_nodes(Nodes, Filename).


### PR DESCRIPTION
This might be useful when privileged access to the cluster machines is difficult, or for use in a web GUI. Details about the resource are in the README.
