### PR TITLE
Cluster_info additions and fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,7 @@ dialyzer: compile
 	@echo Use "'make build_plt'" to build PLT prior to using this target.
 	@echo
 	@sleep 1
-	dialyzer -Wno_return --plt $(COMBO_PLT) deps/*/ebin | \
-	    fgrep -v -f ./dialyzer.ignore-warnings
+	dialyzer -Wno_return --plt $(COMBO_PLT) ebin/*.beam
 
 cleanplt:
 	@echo 

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 %%% -*- mode: erlang -*-
 
 %% Erlang compiler options
-{erl_opts, [warnings_as_errors
+{erl_opts, [warnings_as_errors, debug_info
             , {i, "./priv/"}
            ]}.
 

--- a/src/cluster_info.app.src
+++ b/src/cluster_info.app.src
@@ -22,7 +22,7 @@
 {application, cluster_info,
  [
   {description, "Cluster info/postmortem app"},
-  {vsn, "1.2.1"},
+  {vsn, "1.2.2"},
   {registered, []},
   {applications, [kernel, stdlib, sasl]},
   {mod, {cluster_info, []}},

--- a/src/cluster_info.erl
+++ b/src/cluster_info.erl
@@ -123,7 +123,7 @@ dump_local_node(Path) ->
 %%      File.
 -spec dump_all_connected(filename()) -> [dump_return()].
 dump_all_connected(Path) ->
-    dump_nodes([node()|nodes()], Path).
+    dump_nodes(lists:sort([node()|nodes()]), Path).
 
 %% @doc Dump the cluster_info on all specified nodes to the specified
 %%      File.

--- a/src/cluster_info_basic.erl
+++ b/src/cluster_info_basic.erl
@@ -192,10 +192,7 @@ non_zero_mailboxes(C) ->
 
 suspicious_links_monitors(C) ->
     Min = 1000,
-erlang:put(kk, true),
-catch
     cluster_info:format(C, " Minimum threshold = ~p\n\n", [Min]),
-erlang:erase(kk),
     [begin
          L = lists:sort([{Num, Pid} ||
                             Pid <- processes(),

--- a/src/cluster_info_basic.erl
+++ b/src/cluster_info_basic.erl
@@ -45,6 +45,7 @@ cluster_info_generator_funs() ->
      {"erlang:memory() summary", fun erlang_memory/1},
      {"Top 50 process memory hogs", fun(C) -> memory_hogs(C, 50) end},
      {"Non-zero mailbox sizes", fun non_zero_mailboxes/1},
+     {"Suspicious link and monitor counts", fun suspicious_links_monitors/1},
      {"Registered process names", fun registered_names/1},
      {"Registered process name via regs()", fun capture_regs/1},
      {"Ports", fun port_info/1},
@@ -188,6 +189,19 @@ non_zero_mailboxes(C) ->
                            [catch process_info(Pid, message_queue_len)],
                        Size > 0]),
     cluster_info:format(C, " ~p\n", [lists:reverse(L)]).
+
+suspicious_links_monitors(C) ->
+    Min = 1000,
+    cluster_info:format(" C: Minimum threshold = ~p\n\n", [Min]),
+    [begin
+         L = lists:sort([{Num, Pid} ||
+                            Pid <- processes(),
+                            [{_, Mon}] <- [process_info(Pid, [Type])],
+                            Num <- [length(Mon)],
+                            Num >= Min]),
+         cluster_info:format(C, " Type: ~p\n\n", [Type]),
+         cluster_info:format(C, "    ~p\n\n", [L])
+     end || Type <- [links, monitors]].
 
 port_info(C) ->
     L = [{Port, catch erlang:port_info(Port)} || Port <- erlang:ports()],

--- a/src/cluster_info_basic.erl
+++ b/src/cluster_info_basic.erl
@@ -1,6 +1,6 @@
 %%%----------------------------------------------------------------------
 %%% Copyright: (c) 2009-2010 Gemini Mobile Technologies, Inc.  All rights reserved.
-%%% Copyright: (c) 2010 Basho Technologies, Inc.  All rights reserved.
+%%% Copyright: (c) 2010-2012 Basho Technologies, Inc.  All rights reserved.
 %%%
 %%% Licensed under the Apache License, Version 2.0 (the "License");
 %%% you may not use this file except in compliance with the License.
@@ -96,7 +96,11 @@ capture_regs(C) ->
       C, cluster_info:capture_io(1000, fun() -> shell_default:regs() end)).
 
 erlang_memory(C) ->
-    cluster_info:format(C, " ~p\n", [erlang:memory()]).
+    cluster_info:format(C, " Native report:\n\n"),
+    cluster_info:format(C, " ~p\n\n", [erlang:memory()]),
+    cluster_info:format(C, " Report sorted by memory usage:\n\n"),
+    SortFun = fun({_, X}, {_, Y}) -> X > Y end,
+    cluster_info:format(C, " ~p\n", [lists:sort(SortFun, erlang:memory())]).
 
 erlang_statistics(C) ->
     [cluster_info:format(C, " ~p: ~p\n", [Type, catch erlang:statistics(Type)])


### PR DESCRIPTION
This branch merges three other feature branches which, in total, add the following stuff:
- Add primitive flow control to the client -> server reporting protocol
- Add 'Suspicious link and monitor counts' report
- Display the `erlang:memory()` data both as-is and sorted with the biggest at the top (for lazy report readers)
- Add ability to specify which callback modules you wish to report on.
  The default is all available callback modules.
- Very basic HTML output, including table-of-contents-style links at the node & reports-per-node levels.
