### PR TITLE
use lager_format:format/4 if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,26 +42,20 @@ Configuring maximum string length formatting limits
 It's a well-known feature of Erlang that the default string
 representation is a list of byte values.  Strings can consume much
 more RAM than if the equivalent data were stored in the Erlang binary
-data type instead.  If a prerequisite OTP application, `riak_err`, is
+data type instead.  If a prerequisite OTP application, `lager`, is
 available, then this application can use the
-`riak_err_handler:limited_fmt/4` function to attempt to limit the
+`lager:limited_fmt/3` function to attempt to limit the
 amount of memory used while generating reports.
 
 To limit the amount of RAM used to format strings in a report, this
 application will attempt to fetch the following OTP application
-environment variables from either the `riak_err` app's variables or
-the `cluster_info` app's variables:
+environment variable from the `cluster_info` app's variables:
 
-* `term_max_size` Report output is formatted via
-`cluster_info:format(FormatString, ArgList)` calls.
-If the total size of ArgList is more than `term_max_size`,
-then we'll ignore `FormatString` and log the message with a well-known
-(and therefore safe) formatting string instead.
 * `fmt_max_bytes` When formatting a log-related term that might
 be "big", limit the term's formatted output to a maximum of
 `fmt_max_bytes` bytes.  
 
-The default for both values is 256KB.
+The default value is 256KB.
 
 You have several options for configuring these OTP application
 environment variables:
@@ -86,15 +80,8 @@ environment variables:
     `application:set_env(cluster_info, term_max_size, 65536),
     application:set_env(cluster_info, fmt_max_bytes, 65536)`
 
-If the `term_max_size` environment variable is not defined (by neither
-the `riak_err` application nor the `cluster_info` application), then
+If the `fmt_max_bytes` environment variable is not defined, then
 the length of formatted strings will not be restricted.
-
-If the `term_max_size` environment variable is defined but the BEAM
-object file `riak_err_handler` is not available, then attempts to
-generate a report will throw undefined function exceptions.  As noted
-at the top of this section, the `riak_err` application must be
-compiled and packaged together with the `cluster_info` application.
 
 Licensing
 ---------

--- a/src/cluster_info.erl
+++ b/src/cluster_info.erl
@@ -320,22 +320,19 @@ safe_format(Fmt, Args) ->
     case get_limits() of
         {undefined, _} ->
             io_lib:format(Fmt, Args);
-        {TermMaxSize, FmtMaxBytes} ->
-            riak_err_handler:limited_fmt(Fmt, Args, TermMaxSize, FmtMaxBytes)
+        {lager, FmtMaxBytes} ->
+            lager:limited_fmt(Fmt, Args, FmtMaxBytes)
     end.
 
 get_limits() ->
     case erlang:get(?DICT_KEY) of
         undefined ->
-            case code:which(riak_err_handler) of
+            case code:which(lager) of 
                 non_existing ->
                     {undefined, undefined};
                 _ ->
-                    %% Use factor of 4 because riak_err's settings are
-                    %% fairly conservative by default, e.g. 64KB.
-                    Apps = [{riak_err, 4}, {cluster_info, 1}],
-                    Res = {try_app_envs(Apps, term_max_size, default_size()),
-                           try_app_envs(Apps, fmt_max_bytes, default_size())},
+                    Res = {lager, try_app_envs([cluster_info], fmt_max_bytes,
+                            default_size())},
                     erlang:put(?DICT_KEY, Res),
                     Res
             end;

--- a/src/cluster_info.erl
+++ b/src/cluster_info.erl
@@ -321,17 +321,17 @@ safe_format(Fmt, Args) ->
         {undefined, _} ->
             io_lib:format(Fmt, Args);
         {lager, FmtMaxBytes} ->
-            lager:limited_fmt(Fmt, Args, FmtMaxBytes)
+            lager_format:format(Fmt, Args, FmtMaxBytes,[])
     end.
 
 get_limits() ->
     case erlang:get(?DICT_KEY) of
         undefined ->
-            case code:which(lager) of 
+            case code:which(lager_format) of 
                 non_existing ->
                     {undefined, undefined};
                 _ ->
-                    Res = {lager, try_app_envs([cluster_info], fmt_max_bytes,
+                    Res = {lager, app_helper:get_env(cluster_info, fmt_max_bytes,
                             default_size())},
                     erlang:put(?DICT_KEY, Res),
                     Res
@@ -343,16 +343,6 @@ get_limits() ->
 reset_limits() -> erlang:erase(?DICT_KEY).
 
 default_size() -> 256*1024.
-
-try_app_envs([{App, Factor}|Apps], Key, Default) ->
-    case application:get_env(App, Key) of
-        undefined ->
-            try_app_envs(Apps, Key, Default);
-        {ok, N} ->
-            N * Factor
-    end;
-try_app_envs([], _, Default) ->
-    Default.
 
 make_anchor(Node0, Mod, Name) ->
     NameNoSp = re:replace(Name, " ", "",


### PR DESCRIPTION
riak_err is no longer packaged with Riak, so use lager to perform truncation instead.
