### PR TITLE
Update formatter for pretty print

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -1,2 +1,2 @@
 Unknown functions:
-  lager_format:format/4
+  lager_trunc_io:print/2

--- a/rebar.config
+++ b/rebar.config
@@ -6,5 +6,5 @@
            ]}.
 
 {xref_checks, []}.
-{xref_queries, [{"(XC - UC) || (XU - X - B - \"(lager_format)\" : Mod)", []}]}.
+{xref_queries, [{"(XC - UC) || (XU - X - B - \"(lager_trunc_io)\" : Mod)", []}]}.
 


### PR DESCRIPTION
Current cluster_info writes each term as one line into a file (e.g. memory_hogs) if dependencies include lager. But it would be good that cluster_info's output was human readable. So, this PR changes formatter to use io_lib. Internal function `limited_fmt/2` is brought from riak_err repo which has original code to truncate large term by fmt_max_bytes & fmt_max_bytes.
