### PR TITLE
Use ReplyAs data from io_request in io_reply to comply IO protocol

### DIFF
--- a/src/cluster_info.erl
+++ b/src/cluster_info.erl
@@ -295,8 +295,8 @@ capture_io2(Timeout, Fun, Parent) ->
 
 get_io_reqs(Parent, Timeout) ->
     receive
-        {io_request, From, _, Req} ->
-            From ! {io_reply, self(), ok},
+        {io_request, From, ReplyAs, Req} ->
+            From ! {io_reply, ReplyAs, ok},
             Parent ! {io_data, Req},
             get_io_reqs(Parent, Timeout)
     after Timeout ->


### PR DESCRIPTION
Quote from: Erlang -- The Erlang I/O-protocol [1]

```
    {io_request, From, ReplyAs, Request}
    {io_reply, ReplyAs, Reply}

    The ReplyAs element should be considered opaque by the I/O server.
```

`ReplyAs` was pid but it has been changed to reference in `io` module [2].
By using `ReplyAs` in `io_request`, `cluster_info:capture_io/2` works (should
work) both before and after the change.

[1] http://www.erlang.org/doc/apps/stdlib/io_protocol.html
[2] Optimise io requests for long message queues · basho/otp@69e8387
    https://github.com/basho/otp/commit/69e8387629bdea141e196c515f4d9381f7ac3e18?w=1
