### PR TITLE
Remove dialyzer.ignore-warnings file

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -1,2 +1,0 @@
-Unknown functions:
-  lager_trunc_io:print/2


### PR DESCRIPTION
This appears to be obsolete; running "make dialyzer" does not produce any warnings, even after this file is deleted.